### PR TITLE
[IMAGE SCALING] Bound item images within boxes, centered.

### DIFF
--- a/chezbetty/static/css/chezbetty-admin.css
+++ b/chezbetty/static/css/chezbetty-admin.css
@@ -172,4 +172,14 @@ tfoot tr td {
   background-color: white;
 }
 
-
+/* Center an image and automatically scale to its containing box */
+/* NOTE: this is bigger than item images in purchasing interface. This is
+due to the fact that the admin interface scales boxes differently, and so
+required an absolute height and width provided. Percents won't work. RIP.*/
+.item-img-boundingbox {
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 200px;
+    width: 200px;
+}

--- a/chezbetty/static/css/chezbetty-common.css
+++ b/chezbetty/static/css/chezbetty-common.css
@@ -41,12 +41,3 @@
 .fitin {
 	overflow: hidden;
 }
-
-/* Center an image and automatically scale to its containing box */
-.item-img-boundingbox {
-    background-size: contain;
-    background-position: center;
-    background-repeat: no-repeat;
-    height: 80%;
-    width: 100%;
-}

--- a/chezbetty/static/css/chezbetty-common.css
+++ b/chezbetty/static/css/chezbetty-common.css
@@ -42,3 +42,11 @@
 	overflow: hidden;
 }
 
+/* Center an image and automatically scale to its containing box */
+.item-img-boundingbox {
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 80%;
+    width: 100%;
+}

--- a/chezbetty/static/css/chezbetty-terminal.css
+++ b/chezbetty/static/css/chezbetty-terminal.css
@@ -125,6 +125,14 @@ h2.big-debt {
 	float: left;
 }
 
+.item-img-boundingbox {
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 80%;
+    width: 100%;
+}
+
 .btn-back {
 	width: 250px;
 	height: 100px;

--- a/chezbetty/static/css/chezbetty-terminal.css
+++ b/chezbetty/static/css/chezbetty-terminal.css
@@ -125,6 +125,15 @@ h2.big-debt {
 	float: left;
 }
 
+/* Center an image and automatically scale to its containing box */
+.item-img-boundingbox {
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 80%;
+    width: 100%;
+}
+
 .btn-back {
 	width: 250px;
 	height: 100px;

--- a/chezbetty/static/css/chezbetty-terminal.css
+++ b/chezbetty/static/css/chezbetty-terminal.css
@@ -125,14 +125,6 @@ h2.big-debt {
 	float: left;
 }
 
-.item-img-boundingbox {
-    background-size: contain;
-    background-position: center;
-    background-repeat: no-repeat;
-    height: 80%;
-    width: 100%;
-}
-
 .btn-back {
 	width: 250px;
 	height: 100px;

--- a/chezbetty/templates/admin/item_edit.jinja2
+++ b/chezbetty/templates/admin/item_edit.jinja2
@@ -66,7 +66,7 @@
         </div>
         <div class="col-lg-3 col-md-3 hidden-sm hidden-xs">
           {% if item.img %}
-          <img src="/dynamic/item/{{item.id}}.jpg" width="200px" />
+          <div class="item-img-boundingbox" style="background-image: url('/dynamic/item/{{item.id}}.jpg');"></div>
           {% else %}
           <img src="{{'chezbetty:static/placeholder_300px.png'|static_url}}" width="200px" />
           {% endif %}

--- a/chezbetty/templates/terminal/purchase_nobarcode_items.jinja2
+++ b/chezbetty/templates/terminal/purchase_nobarcode_items.jinja2
@@ -2,7 +2,7 @@
 {% for item in tag.nobarcode_items %}
 <div class="tag-item" data-item-id="{{ item.id }}">
   {% if item.img %}
-  <img src="/dynamic/item/{{item.id}}.jpg" width="150px" />
+  <div class="item-img-boundingbox" style="background-image: url('/dynamic/item/{{item.id}}.jpg');"></div>
   {% else %}
   <img src="{{'chezbetty:static/placeholder_300px.png'|static_url}}" width="150px" />
   {% endif %}

--- a/chezbetty/templates/terminal/terminal.jinja2
+++ b/chezbetty/templates/terminal/terminal.jinja2
@@ -221,7 +221,7 @@
           <div class="col-md-2">
             <div class="tag-item" data-item-id="{{ item.id }}">
               {% if item.img %}
-              <img src="/dynamic/item/{{item.id}}.jpg" width="150px" />
+              <div class="item-img-boundingbox" style="background-image: url('/dynamic/item/{{item.id}}.jpg');"></div>
               {% else %}
               <img src="{{'chezbetty:static/placeholder_300px.png'|static_url}}" width="150px" />
               {% endif %}


### PR DESCRIPTION
Fixes issue where items in the "Recently Purchased Items" area have
their images scaled outside of the boundaries of the boxes. Also aligns
the item name text along the bottom of those boxes. Makes it nicer.

*Before Fix:*
![before-fix](https://user-images.githubusercontent.com/9910283/61906869-45589100-aefa-11e9-8ef2-52d67b5f6f6b.png)

*After Fix:*
![after-fix](https://user-images.githubusercontent.com/9910283/61906891-51445300-aefa-11e9-8473-fb22ae0d0f54.png)